### PR TITLE
Fix unauthorized sessions, auth data, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SSL certificates and the following environment variables are managed by [Park Ra
 - `SYNC_SERVER_SESSION_SECRET`: Secret, non-obvious string used to prevent session tampering (e.g. `oc]7kwM)R*UX3&` but *generate your own*; required to run app)
 - `SYNC_SERVER_DEPLOY_HOST_USERNAME`: User name with which to SSH into remote deployment server (e.g. `root`; required to deploy app)
 - `SYNC_SERVER_WEB_HOST`: Host address for the web client intended to communicate with the app exclusively via cross-origin HTTP requests; used to set HTTP access control (CORS) (e.g. `http://example.com:9019`; optional)
-- `SYNC_SERVER_DEPLOY_CERTS_DIR`: Local system path to a directory with the SSL certificate files `key`, `crt` and `ca` needed by the app to serve HTTPs requests *remotely on the deployment server* (e.g. `/var/www/sync-server/.certs-deploy`; required to deploy app). This directory will be copied to `.certs` within the base directory of the app on the deployment server so the environment variable `SYNC_SERVER_CERTS_DIR` must be set to `.certs` in the deployment environment unless this directory is later moved.
+- `SYNC_SERVER_DEPLOY_CERTS_DIR`: Local system path to a directory with the SSL certificate files `key`, `crt` and `ca` needed by the app to serve HTTPs requests *remotely on the deployment server* (e.g. `/var/www/sync-server/.cert-deploy`; required to deploy app). This directory will be copied to `.cert` within the base directory of the app on the deployment server so the environment variable `SYNC_SERVER_CERTS_DIR` must be set to `.cert` in the deployment environment unless this directory is later moved.
 - `SYNC_SERVER_DEPLOY_HOST`: Host address for the remote deployment server (e.g. `example.com`; required to deploy app)
 - `SYNC_SERVER_DEPLOY_HOST_DIR`: Remote system path to app directory on deployment server (e.g. `/var/www/sync-server`; required to deploy app)
 - `SYNC_SERVER_DEPLOY_SYSTEMD_SERVICE`: Name of systemd service on host that should be restarted or started upon app deployment (e.g. `syncserver`; optional to deploy app)
@@ -35,7 +35,7 @@ SSL certificates and the following environment variables are managed by [Park Ra
 - `SYNC_SERVER_MAILER_DEV_RECIPIENT_EMAIL`: Email address used by the app to manually test the delivery of email (e.g. `developer@example.com`; required to run app in the development environment but not required to run it in other environments nor to deploy)
 - `SYNC_SERVER_MAILER_LOGGER_EMAIL`: Email address used by the app to report high-priority log events by email (e.g. `developer-support@example.com`; optional)
 - `SYNC_SERVER_LOGGER_FILE_PATH`: File system path where to store log events (e.g. `/tmp/sync-server.log`; optional)
-- `SYNC_SERVER_CERTS_DIR`: Local system path to a directory with the SSL certificate files `key`, `crt` and `ca` needed by the app to serve HTTPs requests (e.g. `/var/www/sync-server/.certs`; required to run app)
+- `SYNC_SERVER_CERTS_DIR`: Local system path to a directory with the SSL certificate files `key`, `crt` and `ca` needed by the app to serve HTTPs requests (e.g. `/var/www/sync-server/.cert`; required to run app)
 - `SYNC_SERVER_SENDGRID_API_KEY`: API key for SendGrid account for delivering email (optional to run app)
 - `SYNC_SERVER_MAILER_RECIPIENT_EMAIL`: Email address to which to restrict all email delivery for testing purposes (optional to run app)
 

--- a/app/index.js
+++ b/app/index.js
@@ -22,7 +22,7 @@ app.use(expressSession({
   secret: sessionConfig.secret,
   store: sessionConfig.store,
   resave: false,
-  saveUninitialized: false
+  saveUninitialized: true
 }));
 app.use(passport.initialize());
 app.use(passport.session());

--- a/app/lib/jsonapi.js
+++ b/app/lib/jsonapi.js
@@ -715,9 +715,6 @@ jsonapi.routeModelResources = function() {
 
   app.use(function(req, res, next) {
     res.set('Content-Type', 'application/vnd.api+json');
-
-    
-
     next();
   });
 

--- a/app/models/contactVerification.js
+++ b/app/models/contactVerification.js
@@ -6,10 +6,10 @@
 var async = require('async');
 var ContactVerificationRequest = require('./contactVerificationRequest');
 var debug = require('debug')('syncServer:contactVerification');
-var logger = require('../lib/logger');
-var modelFactory = require('../factories/model');
-var NotificationRequest = require('./notificationRequest');
-var User = require('./user');
+var logger = require('app/lib/logger');
+var modelFactory = require('app/factories/model');
+var NotificationRequest = require('app/models/notificationRequest');
+var User = require('app/models/user');
 
 /**
  * Represents verification of contact information

--- a/app/models/widget.js
+++ b/app/models/widget.js
@@ -1,0 +1,20 @@
+/**
+ * Widget model
+ * @module
+ */
+
+var modelFactory = require('app/factories/model');
+
+/**
+ * Represents a widget
+ * @class User
+ * @property {string} color - Color of widget
+ */
+module.exports = modelFactory.new('Widget', {
+  color: { type: String, required: true }
+}, {
+  jsonapi: {
+    get: 'public',
+    post: 'public'
+  }
+});

--- a/app/routers/auths.js
+++ b/app/routers/auths.js
@@ -71,7 +71,8 @@ var reqPassportDocument = function(req, res, next) {
       consumerKey: document.clientId,
       consumerSecret: document.clientSecret,
       callbackURL: app.host + path.resolve('/', Model.modelType(), document.slug, 'auth-callback'),
-      passReqToCallback: true
+      passReqToCallback: true,
+      profileFields: ['id', 'displayName', 'emails']
     }, function(req, accessToken, refreshToken, profile, done) {
       var findOrCreateUserAuth = (done) => {
         var conditions = {};


### PR DESCRIPTION
- Set saveUninitialized to true when initializing express-session to persist unauthorized sessions
- Add profileFields attribute to passport strategy init to ensure their availability upon auth
- Fix references to .cert directory in README
- Remove excess line breaks from jsonapi library
- Convert require paths from relative to absolute in contactVerification model